### PR TITLE
feat: Add scenes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm install @lucadiba/switchbot-client
 
 ## Usage
 
+### Client
+
 ```typescript
 import SwitchBot from "@lucadiba/switchbot-client";
 
@@ -36,9 +38,18 @@ const switchbot = new SwitchBot({
   openToken: "openToken",
   secretKey: "secretKey",
 });
+```
 
+### Device
+```typescript
 // Press SwitchBot Bot
 switchbot.bot("deviceId").press();
+```
+
+### Scene
+```typescript
+// Execute SwitchBot Scene
+switchbot.scene("sceneId").execute();
 ```
 
 Supported devices:

--- a/src/SwitchBot.ts
+++ b/src/SwitchBot.ts
@@ -18,8 +18,8 @@ import SwitchBotPlugMini from "./devices/SwitchBotPlugMini.js";
 import SwitchBotRemote from "./devices/SwitchBotRemote.js";
 import SwitchBotRobotVacuumCleaner from "./devices/SwitchBotRobotVacuumCleaner.js";
 import SwitchBotStripLight from "./devices/SwitchBotStripLight.js";
-import { DeviceId, GetAllDevicesResponse, GetAllScenesResponse, SceneId } from "./types.js";
 import { Scene } from "./scenes/Scene.js";
+import { DeviceId, GetAllDevicesResponse, GetAllScenesResponse, SceneId } from "./types.js";
 
 export type SwitchBotOptions = {
   openToken: string;

--- a/src/SwitchBot.ts
+++ b/src/SwitchBot.ts
@@ -18,7 +18,8 @@ import SwitchBotPlugMini from "./devices/SwitchBotPlugMini.js";
 import SwitchBotRemote from "./devices/SwitchBotRemote.js";
 import SwitchBotRobotVacuumCleaner from "./devices/SwitchBotRobotVacuumCleaner.js";
 import SwitchBotStripLight from "./devices/SwitchBotStripLight.js";
-import { DeviceId, GetAllDevicesResponse } from "./types.js";
+import { DeviceId, GetAllDevicesResponse, GetAllScenesResponse, SceneId } from "./types.js";
+import { Scene } from "./scenes/Scene.js";
 
 export type SwitchBotOptions = {
   openToken: string;
@@ -49,6 +50,17 @@ export default class SwitchBot {
       "/v1.1/devices"
     );
     return response.body;
+  };
+
+  public scenes = async () => {
+    const response = await this.getRequest<GetAllScenesResponse>(
+      "/v1.1/scenes"
+    );
+    return response.body;
+  };
+
+  public scene = (sceneId: SceneId) => {
+    return new Scene(sceneId, this.getDeps());
   };
 
   public bot = (deviceId: DeviceId) => {

--- a/src/SwitchBot.ts
+++ b/src/SwitchBot.ts
@@ -18,8 +18,13 @@ import SwitchBotPlugMini from "./devices/SwitchBotPlugMini.js";
 import SwitchBotRemote from "./devices/SwitchBotRemote.js";
 import SwitchBotRobotVacuumCleaner from "./devices/SwitchBotRobotVacuumCleaner.js";
 import SwitchBotStripLight from "./devices/SwitchBotStripLight.js";
-import { Scene } from "./scenes/Scene.js";
-import { DeviceId, GetAllDevicesResponse, GetAllScenesResponse, SceneId } from "./types.js";
+import Scene from "./scenes/Scene.js";
+import {
+  DeviceId,
+  GetAllDevicesResponse,
+  GetAllScenesResponse,
+  SceneId,
+} from "./types.js";
 
 export type SwitchBotOptions = {
   openToken: string;
@@ -45,22 +50,12 @@ export default class SwitchBot {
     });
   }
 
+  // Devices
   public devices = async () => {
     const response = await this.getRequest<GetAllDevicesResponse>(
       "/v1.1/devices"
     );
     return response.body;
-  };
-
-  public scenes = async () => {
-    const response = await this.getRequest<GetAllScenesResponse>(
-      "/v1.1/scenes"
-    );
-    return response.body;
-  };
-
-  public scene = (sceneId: SceneId) => {
-    return new Scene(sceneId, this.getDeps());
   };
 
   public bot = (deviceId: DeviceId) => {
@@ -131,6 +126,19 @@ export default class SwitchBot {
     return new SwitchBotStripLight(deviceId, this.getDeps());
   };
 
+  // Scenes
+  public scenes = async () => {
+    const response = await this.getRequest<GetAllScenesResponse>(
+      "/v1.1/scenes"
+    );
+    return response.body;
+  };
+
+  public scene = (sceneId: SceneId) => {
+    return new Scene(sceneId, this.getDeps());
+  };
+
+  // Internal
   private getDeps = () => ({
     getRequest: this.getRequest,
     postRequest: this.postRequest,

--- a/src/__tests__/SwitchBot.test.ts
+++ b/src/__tests__/SwitchBot.test.ts
@@ -20,6 +20,7 @@ import SwitchBotRemote from "../devices/SwitchBotRemote";
 import SwitchBotRobotVacuumCleaner from "../devices/SwitchBotRobotVacuumCleaner";
 import SwitchBotStripLight from "../devices/SwitchBotStripLight";
 import { getMockedCommandResponse } from "../utils/tests";
+import { Scene } from "../scenes/Scene";
 
 const BASE_URL = "https://api.switch-bot.com";
 const OPEN_TOKEN = "openToken";
@@ -30,77 +31,79 @@ const switchBot = new SwitchBot({
   secretKey: SECRET_KEY,
 });
 const deviceId = "deviceId";
+const sceneId = "sceneId";
 
 describe("requests", () => {
-  test("get", async () => {
-    const mockStatusResponse = {
-      statusCode: 100,
-      body: {
-        deviceList: [
-          {
-            deviceId: "deviceId",
-            deviceName: "deviceName",
-            deviceType: "Bot",
-            hubDeviceId: "hubDeviceId",
-            enableCloudService: true,
-          },
-        ],
-        infraredRemoteList: [],
-      },
-      message: "success",
-    };
-
-    nock(BASE_URL).get(`/v1.1/devices`).reply(200, mockStatusResponse);
-
-    const response = await switchBot.devices();
-
-    expect(response).toEqual(mockStatusResponse.body);
-  });
-
-  test("post", async () => {
-    const mockCommandResponse = getMockedCommandResponse({ deviceId });
-
-    nock(BASE_URL)
-      .post(`/v1.1/devices/${deviceId}/commands`, {
-        command: "press",
-        parameter: "default",
-        commandType: "command",
-      })
-      .reply(200, mockCommandResponse);
-
-    const response = await switchBot.bot(deviceId).press();
-
-    expect(response).toEqual(mockCommandResponse.body.items[0].status);
-  });
-
-  describe("headers", () => {
-    const getExpectedSign = (t: string, nonce: string) => {
-      const data = OPEN_TOKEN + t + nonce;
-      return createHmac("sha256", SECRET_KEY)
-        .update(Buffer.from(data, "utf-8"))
-        .digest()
-        .toString("base64");
-    };
-
+  describe("devices", () => {
     test("get", async () => {
+      const mockStatusResponse = {
+        statusCode: 100,
+        body: {
+          deviceList: [
+            {
+              deviceId: "deviceId",
+              deviceName: "deviceName",
+              deviceType: "Bot",
+              hubDeviceId: "hubDeviceId",
+              enableCloudService: true,
+            },
+          ],
+          infraredRemoteList: [],
+        },
+        message: "success",
+      };
+
+      nock(BASE_URL).get(`/v1.1/devices`).reply(200, mockStatusResponse);
+
+      const response = await switchBot.devices();
+
+      expect(response).toEqual(mockStatusResponse.body);
+    });
+
+    test("post", async () => {
+      const mockCommandResponse = getMockedCommandResponse({ deviceId });
+
       nock(BASE_URL)
-        .get(`/v1.1/devices/${deviceId}/status`)
-        .reply(function (uri, body, callback) {
-          const { sign, nonce, t } = this.req.headers;
+        .post(`/v1.1/devices/${deviceId}/commands`, {
+          command: "press",
+          parameter: "default",
+          commandType: "command",
+        })
+        .reply(200, mockCommandResponse);
 
-          if (sign !== getExpectedSign(t, nonce)) {
-            return callback(new Error("Invalid signature"), [
-              400,
-              "Invalid signature",
-            ]);
-          }
+      const response = await switchBot.bot(deviceId).press();
 
-          callback(null, [200, getMockedCommandResponse({ deviceId })]);
-        });
+      expect(response).toEqual(mockCommandResponse.body.items[0].status);
+    });
 
-      try {
-        const response = await switchBot.bot(deviceId).getStatus();
-        expect(response).toMatchInlineSnapshot(`
+    describe("headers", () => {
+      const getExpectedSign = (t: string, nonce: string) => {
+        const data = OPEN_TOKEN + t + nonce;
+        return createHmac("sha256", SECRET_KEY)
+          .update(Buffer.from(data, "utf-8"))
+          .digest()
+          .toString("base64");
+      };
+
+      test("get", async () => {
+        nock(BASE_URL)
+          .get(`/v1.1/devices/${deviceId}/status`)
+          .reply(function (uri, body, callback) {
+            const { sign, nonce, t } = this.req.headers;
+
+            if (sign !== getExpectedSign(t, nonce)) {
+              return callback(new Error("Invalid signature"), [
+                400,
+                "Invalid signature",
+              ]);
+            }
+
+            callback(null, [200, getMockedCommandResponse({ deviceId })]);
+          });
+
+        try {
+          const response = await switchBot.bot(deviceId).getStatus();
+          expect(response).toMatchInlineSnapshot(`
           {
             "items": [
               {
@@ -112,118 +115,157 @@ describe("requests", () => {
             ],
           }
         `);
-      } catch (e) {
-        throw new Error(e as any);
-      }
+        } catch (e) {
+          throw new Error(e as any);
+        }
+      });
+
+      test("post", async () => {
+        nock(BASE_URL)
+          .post(`/v1.1/devices/${deviceId}/commands`)
+          .reply(function (uri, body, callback) {
+            const { sign, nonce, t } = this.req.headers;
+
+            if (sign !== getExpectedSign(t, nonce)) {
+              return callback(new Error("Invalid signature"), [
+                400,
+                "Invalid signature",
+              ]);
+            }
+
+            if (this.req.headers["content-type"] !== "application/json") {
+              return callback(new Error("Invalid content type"), [
+                400,
+                "Invalid content type",
+              ]);
+            }
+
+            callback(null, [200, getMockedCommandResponse({ deviceId })]);
+          });
+
+        try {
+          const response = await switchBot.bot(deviceId).press();
+          expect(response).toMatchInlineSnapshot(`{}`);
+        } catch (e) {
+          throw new Error(e as any);
+        }
+      });
+    });
+  });
+
+  describe("instantiate devices", () => {
+    test("Bot", () => {
+      expect(switchBot.bot(deviceId)).toBeInstanceOf(SwitchBotBot);
     });
 
-    test("post", async () => {
-      nock(BASE_URL)
-        .post(`/v1.1/devices/${deviceId}/commands`)
-        .reply(function (uri, body, callback) {
-          const { sign, nonce, t } = this.req.headers;
+    test("Camera", () => {
+      expect(switchBot.camera(deviceId)).toBeInstanceOf(SwitchBotCamera);
+    });
 
-          if (sign !== getExpectedSign(t, nonce)) {
-            return callback(new Error("Invalid signature"), [
-              400,
-              "Invalid signature",
-            ]);
-          }
+    test("Ceiling Light", () => {
+      expect(switchBot.ceilingLight(deviceId)).toBeInstanceOf(
+        SwitchBotCeilingLight
+      );
+    });
 
-          if (this.req.headers["content-type"] !== "application/json") {
-            return callback(new Error("Invalid content type"), [
-              400,
-              "Invalid content type",
-            ]);
-          }
+    test("Color Bulb", () => {
+      expect(switchBot.colorBulb(deviceId)).toBeInstanceOf(SwitchBotColorBulb);
+    });
 
-          callback(null, [200, getMockedCommandResponse({ deviceId })]);
-        });
+    test("ContactSensor", () => {
+      expect(switchBot.contactSensor(deviceId)).toBeInstanceOf(
+        SwitchBotContactSensor
+      );
+    });
 
-      try {
-        const response = await switchBot.bot(deviceId).press();
-        expect(response).toMatchInlineSnapshot(`{}`);
-      } catch (e) {
-        throw new Error(e as any);
-      }
+    test("Curtain", () => {
+      expect(switchBot.curtain(deviceId)).toBeInstanceOf(SwitchBotCurtain);
+    });
+
+    test("Hub", () => {
+      expect(switchBot.hub(deviceId)).toBeInstanceOf(SwitchBotHub);
+    });
+
+    test("Humidifier", () => {
+      expect(switchBot.humidifier(deviceId)).toBeInstanceOf(SwitchBotHumidifier);
+    });
+
+    test("Keypad", () => {
+      expect(switchBot.keypad(deviceId)).toBeInstanceOf(SwitchBotKeypad);
+    });
+
+    test("Lock", () => {
+      expect(switchBot.lock(deviceId)).toBeInstanceOf(SwitchBotLock);
+    });
+
+    test("Meter", () => {
+      expect(switchBot.meter(deviceId)).toBeInstanceOf(SwitchBotMeter);
+    });
+
+    test("MotionSensor", () => {
+      expect(switchBot.motionSensor(deviceId)).toBeInstanceOf(
+        SwitchBotMotionSensor
+      );
+    });
+
+    test("Plug", () => {
+      expect(switchBot.plug(deviceId)).toBeInstanceOf(SwitchBotPlug);
+    });
+
+    test("Plug Mini", () => {
+      expect(switchBot.plugMini(deviceId)).toBeInstanceOf(SwitchBotPlugMini);
+    });
+
+    test("Remote", () => {
+      expect(switchBot.remote(deviceId)).toBeInstanceOf(SwitchBotRemote);
+    });
+
+    test("Robot Vacuum Cleaner", () => {
+      expect(switchBot.robotVacuumCleaner(deviceId)).toBeInstanceOf(
+        SwitchBotRobotVacuumCleaner
+      );
+    });
+
+    test("Strip Light", () => {
+      expect(switchBot.stripLight(deviceId)).toBeInstanceOf(SwitchBotStripLight);
     });
   });
 });
 
-describe("instantiate devices", () => {
-  test("Bot", () => {
-    expect(switchBot.bot(deviceId)).toBeInstanceOf(SwitchBotBot);
-  });
+describe("scenes", () => {
+  test("get", async () => {
+    const mockStatusResponse = {
+      statusCode: 100,
+      body: [
+        { sceneId: "scene1", sceneName: "Scene 1" },
+        { sceneId: "scene2", sceneName: "Scene 2" },
+        { sceneId: "scene3", sceneName: "Scene 3" }
+      ],
+      message: "success",
+    };
 
-  test("Camera", () => {
-    expect(switchBot.camera(deviceId)).toBeInstanceOf(SwitchBotCamera);
-  });
+    nock(BASE_URL).get(`/v1.1/scenes`).reply(200, mockStatusResponse);
 
-  test("Ceiling Light", () => {
-    expect(switchBot.ceilingLight(deviceId)).toBeInstanceOf(
-      SwitchBotCeilingLight
-    );
-  });
+    const response = await switchBot.scenes();
 
-  test("Color Bulb", () => {
-    expect(switchBot.colorBulb(deviceId)).toBeInstanceOf(SwitchBotColorBulb);
+    expect(response).toEqual(mockStatusResponse.body);
   });
+  test("post", async () => {
+    const mockStatusResponse = {
+      statusCode: 100,
+      body: {},
+      message: "success",
+    };
 
-  test("ContactSensor", () => {
-    expect(switchBot.contactSensor(deviceId)).toBeInstanceOf(
-      SwitchBotContactSensor
-    );
+    nock(BASE_URL).post(`/v1.1/scenes/${sceneId}/execute`).reply(200, mockStatusResponse);
+
+    const response = await switchBot.scene(sceneId).execute();
+
+    expect(response).toEqual(mockStatusResponse.body);
   });
-
-  test("Curtain", () => {
-    expect(switchBot.curtain(deviceId)).toBeInstanceOf(SwitchBotCurtain);
-  });
-
-  test("Hub", () => {
-    expect(switchBot.hub(deviceId)).toBeInstanceOf(SwitchBotHub);
-  });
-
-  test("Humidifier", () => {
-    expect(switchBot.humidifier(deviceId)).toBeInstanceOf(SwitchBotHumidifier);
-  });
-
-  test("Keypad", () => {
-    expect(switchBot.keypad(deviceId)).toBeInstanceOf(SwitchBotKeypad);
-  });
-
-  test("Lock", () => {
-    expect(switchBot.lock(deviceId)).toBeInstanceOf(SwitchBotLock);
-  });
-
-  test("Meter", () => {
-    expect(switchBot.meter(deviceId)).toBeInstanceOf(SwitchBotMeter);
-  });
-
-  test("MotionSensor", () => {
-    expect(switchBot.motionSensor(deviceId)).toBeInstanceOf(
-      SwitchBotMotionSensor
-    );
-  });
-
-  test("Plug", () => {
-    expect(switchBot.plug(deviceId)).toBeInstanceOf(SwitchBotPlug);
-  });
-
-  test("Plug Mini", () => {
-    expect(switchBot.plugMini(deviceId)).toBeInstanceOf(SwitchBotPlugMini);
-  });
-
-  test("Remote", () => {
-    expect(switchBot.remote(deviceId)).toBeInstanceOf(SwitchBotRemote);
-  });
-
-  test("Robot Vacuum Cleaner", () => {
-    expect(switchBot.robotVacuumCleaner(deviceId)).toBeInstanceOf(
-      SwitchBotRobotVacuumCleaner
-    );
-  });
-
-  test("Strip Light", () => {
-    expect(switchBot.stripLight(deviceId)).toBeInstanceOf(SwitchBotStripLight);
+  describe("instantiate scenes", () => {
+    test("Scene", () => {
+      expect(switchBot.scene(sceneId)).toBeInstanceOf(Scene);
+    });
   });
 });

--- a/src/__tests__/SwitchBot.test.ts
+++ b/src/__tests__/SwitchBot.test.ts
@@ -19,8 +19,8 @@ import SwitchBotPlugMini from "../devices/SwitchBotPlugMini";
 import SwitchBotRemote from "../devices/SwitchBotRemote";
 import SwitchBotRobotVacuumCleaner from "../devices/SwitchBotRobotVacuumCleaner";
 import SwitchBotStripLight from "../devices/SwitchBotStripLight";
-import { getMockedCommandResponse } from "../utils/tests";
 import { Scene } from "../scenes/Scene";
+import { getMockedCommandResponse } from "../utils/tests";
 
 const BASE_URL = "https://api.switch-bot.com";
 const OPEN_TOKEN = "openToken";

--- a/src/devices/Device.ts
+++ b/src/devices/Device.ts
@@ -8,7 +8,7 @@ import {
   Deps,
   DeviceCommandResponse,
   DeviceId,
-  DeviceStatusReponse,
+  DeviceStatusResponse,
 } from "../types.js";
 import { DEVICE_TYPES_ARRAY } from "../utils/constant.js";
 import {
@@ -51,7 +51,7 @@ export class DeviceWithStatus<
     }
 
     const response = await this._deps.getRequest<
-      DeviceStatusReponse<DeviceStatusBody>
+      DeviceStatusResponse<DeviceStatusBody>
     >(this._getPath("/status"));
 
     this._cachedStatus = returnDeviceStatusBodyOrThrow(response);

--- a/src/scenes/Scene.ts
+++ b/src/scenes/Scene.ts
@@ -7,6 +7,7 @@ import { returnSceneExecuteBodyOrThrow } from "../utils/response.js";
 
 export class Scene {
   protected readonly _sceneId: SceneId;
+
   protected readonly _deps: Deps;
 
   constructor(sceneId: SceneId, deps: Deps) {

--- a/src/scenes/Scene.ts
+++ b/src/scenes/Scene.ts
@@ -1,0 +1,26 @@
+import {
+  Deps,
+  SceneExecuteResponse,
+  SceneId
+} from "../types.js";
+import { returnSceneExecuteBodyOrThrow } from "../utils/response.js";
+
+export class Scene {
+  protected readonly _sceneId: SceneId;
+  protected readonly _deps: Deps;
+
+  constructor(sceneId: SceneId, deps: Deps) {
+    this._sceneId = sceneId;
+    this._deps = deps;
+  }
+
+  public async execute() {
+    const res = await this._deps.postRequest<SceneExecuteResponse<{}>>(this._getPath("/execute"), {})
+
+    return returnSceneExecuteBodyOrThrow(res)
+  }
+
+  protected _getPath = (path: string) => {
+    return `/v1.1/scenes/${this._sceneId}${path}`;
+  };
+}

--- a/src/scenes/Scene.ts
+++ b/src/scenes/Scene.ts
@@ -1,11 +1,7 @@
-import {
-  Deps,
-  SceneExecuteResponse,
-  SceneId
-} from "../types.js";
+import { Deps, SceneExecuteResponse, SceneId } from "../types.js";
 import { returnSceneExecuteBodyOrThrow } from "../utils/response.js";
 
-export class Scene {
+export default class Scene {
   protected readonly _sceneId: SceneId;
 
   protected readonly _deps: Deps;
@@ -16,9 +12,12 @@ export class Scene {
   }
 
   public async execute() {
-    const res = await this._deps.postRequest<SceneExecuteResponse<{}>>(this._getPath("/execute"), {})
+    const res = await this._deps.postRequest<SceneExecuteResponse<{}>>(
+      this._getPath("/execute"),
+      {}
+    );
 
-    return returnSceneExecuteBodyOrThrow(res)
+    return returnSceneExecuteBodyOrThrow(res);
   }
 
   protected _getPath = (path: string) => {

--- a/src/scenes/__tests__/Scene.test.ts
+++ b/src/scenes/__tests__/Scene.test.ts
@@ -1,0 +1,31 @@
+import { Deps } from "../../types";
+import { getMockedSceneExecuteResponse } from "../../utils/tests";
+import Scene from "../Scene";
+
+const sceneId = "sceneId";
+
+let scene: Scene;
+let deps: Deps;
+let mockCommandResponse = getMockedSceneExecuteResponse({ sceneId });
+
+beforeEach(() => {
+  deps = {
+    getRequest: jest.fn(),
+    postRequest: jest.fn(),
+  };
+  scene = new Scene(sceneId, deps);
+  mockCommandResponse = getMockedSceneExecuteResponse({ sceneId });
+});
+
+test("press", async () => {
+  deps.postRequest = jest.fn().mockReturnValueOnce(mockCommandResponse);
+
+  await scene.execute();
+
+  expect(deps.getRequest).toBeCalledTimes(0);
+  expect(deps.postRequest).toBeCalledTimes(1);
+  expect(deps.postRequest).toBeCalledWith(
+    `/v1.1/scenes/${sceneId}/execute`,
+    {}
+  );
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export type Deps = {
 
 export type DeviceId = string;
 
+export type SceneId = string;
+
 export type SwitchBotResponse<T> = {
   statusCode: number;
   message: string;
@@ -58,7 +60,13 @@ export type GetAllDevicesResponse = SwitchBotResponse<{
   }>;
 }>;
 
-export type DeviceStatusReponse<T> = SwitchBotResponse<T>;
+export type GetAllScenesResponse = SwitchBotResponse<
+  { sceneId: string; sceneName: string; }[]
+>;
+
+export type SceneExecuteResponse<T> = SwitchBotResponse<T>;
+
+export type DeviceStatusResponse<T> = SwitchBotResponse<T>;
 
 export type DeviceCommandResponse<T> = SwitchBotResponse<{
   items: {

--- a/src/utils/__tests__/response.test.ts
+++ b/src/utils/__tests__/response.test.ts
@@ -1,14 +1,15 @@
-import { DeviceStatusReponse } from "../../types";
+import { DeviceStatusResponse, SceneExecuteResponse } from "../../types";
 import { SWITCHBOT_RESPONSE_STATUS_OK } from "../constant";
 import {
   returnDeviceCommandBodyOrThrow,
   returnDeviceStatusBodyOrThrow,
+  returnSceneExecuteBodyOrThrow,
 } from "../response";
 import { getMockedCommandResponse } from "../tests";
 
 describe("returnDeviceStatusBodyOrThrow", () => {
   it("should return body", () => {
-    const response: DeviceStatusReponse<string> = {
+    const response: DeviceStatusResponse<string> = {
       statusCode: SWITCHBOT_RESPONSE_STATUS_OK,
       body: "body",
       message: "message",
@@ -20,7 +21,7 @@ describe("returnDeviceStatusBodyOrThrow", () => {
   it("should throw error", () => {
     const ERROR_MESSAGE = "error message";
 
-    const response: DeviceStatusReponse<string> = {
+    const response: DeviceStatusResponse<string> = {
       statusCode: 400,
       body: "body",
       message: ERROR_MESSAGE,
@@ -80,5 +81,31 @@ describe("returnDeviceCommandBodyOrThrow", () => {
     expect(() =>
       returnDeviceCommandBodyOrThrow(response)
     ).toThrowErrorMatchingInlineSnapshot(`"Unexpected items length: 0"`);
+  });
+});
+
+describe("returnSceneExecuteBodyOrThrow", () => {
+  it("should return body", () => {
+    const response: SceneExecuteResponse<string> = {
+      statusCode: SWITCHBOT_RESPONSE_STATUS_OK,
+      body: "body",
+      message: "message",
+    };
+
+    expect(returnSceneExecuteBodyOrThrow(response)).toBe("body");
+  });
+
+  it("should throw error", () => {
+    const ERROR_MESSAGE = "error message";
+
+    const response: SceneExecuteResponse<string> = {
+      statusCode: 400,
+      body: "body",
+      message: ERROR_MESSAGE,
+    };
+
+    expect(() =>
+      returnSceneExecuteBodyOrThrow(response)
+    ).toThrowErrorMatchingInlineSnapshot(`"error message"`);
   });
 });

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,8 +1,18 @@
-import { DeviceCommandResponse, DeviceStatusReponse } from "../types.js";
+import { DeviceCommandResponse, DeviceStatusResponse, SceneExecuteResponse } from "../types.js";
 import { SWITCHBOT_RESPONSE_STATUS_OK } from "./constant.js";
 
 export const returnDeviceStatusBodyOrThrow = <T>(
-  response: DeviceStatusReponse<T>
+  response: DeviceStatusResponse<T>
+) => {
+  if (response.statusCode === SWITCHBOT_RESPONSE_STATUS_OK) {
+    return response.body;
+  }
+
+  throw new Error(response.message);
+};
+
+export const returnSceneExecuteBodyOrThrow = <T>(
+  response: SceneExecuteResponse<T>
 ) => {
   if (response.statusCode === SWITCHBOT_RESPONSE_STATUS_OK) {
     return response.body;

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,4 +1,11 @@
-import { DeviceCommandResponse, DeviceId, DeviceStatusResponse } from "../types";
+import {
+  DeviceCommandResponse,
+  DeviceId,
+  DeviceStatusResponse,
+  GetAllScenesResponse,
+  SceneExecuteResponse,
+  SceneId,
+} from "../types";
 import { SWITCHBOT_RESPONSE_STATUS_OK } from "./constant";
 
 export const getMockedStatusResponse = <T>({
@@ -48,4 +55,43 @@ export const getMockedCommandResponse = <T>({
       ],
     },
   } as DeviceCommandResponse<T>;
+};
+
+export const getMockedScenesListResponse = ({
+  sceneId,
+  sceneName,
+
+  mainStatusCode,
+  mainMessage,
+}: {
+  sceneId: SceneId;
+  sceneName: string;
+  mainStatusCode?: number;
+  mainMessage?: string;
+}) => {
+  return {
+    statusCode: mainStatusCode ?? SWITCHBOT_RESPONSE_STATUS_OK,
+    message: mainMessage ?? "success",
+    body: [
+      {
+        sceneId,
+        sceneName,
+      },
+    ],
+  } as GetAllScenesResponse;
+};
+
+export const getMockedSceneExecuteResponse = <T>({
+  mainStatusCode,
+  mainMessage,
+}: {
+  sceneId: SceneId;
+  mainStatusCode?: number;
+  mainMessage?: string;
+}) => {
+  return {
+    statusCode: mainStatusCode ?? SWITCHBOT_RESPONSE_STATUS_OK,
+    message: mainMessage ?? "success",
+    body: {},
+  } as SceneExecuteResponse<T>;
 };

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,4 +1,4 @@
-import { DeviceCommandResponse, DeviceId, DeviceStatusReponse } from "../types";
+import { DeviceCommandResponse, DeviceId, DeviceStatusResponse } from "../types";
 import { SWITCHBOT_RESPONSE_STATUS_OK } from "./constant";
 
 export const getMockedStatusResponse = <T>({
@@ -14,7 +14,7 @@ export const getMockedStatusResponse = <T>({
     statusCode: statusCode ?? SWITCHBOT_RESPONSE_STATUS_OK,
     message: message ?? "success",
     body: body ?? {},
-  } as DeviceStatusReponse<T>;
+  } as DeviceStatusResponse<T>;
 };
 
 export const getMockedCommandResponse = <T>({


### PR DESCRIPTION
This PR adds support for listing and executing `Scenes` using the SwitchBot API v1.1.

They have a pretty simple interface with only one operation that takes no data from the consumer. The new functionality is supported by tests. The contributions are intended to be in keeping with the existing style and approach to within this project.

This PR also fixes an existing typo in the repo.