### PR TITLE
add prefix to crypto import

### DIFF
--- a/src/SwitchBot.ts
+++ b/src/SwitchBot.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from "axios";
-import { createHmac, randomUUID } from "crypto";
+import { createHmac, randomUUID } from "node:crypto";
 
 import SwitchBotBlindTilt from "./devices/SwitchBotBlindTilt";
 import SwitchBotBot from "./devices/SwitchBotBot";


### PR DESCRIPTION
I'd like to use this library in a Cloudflare worker, which only works with "node:" prefixed imports.
https://2ality.com/2021/12/node-protocol-imports.html
Since this has been the default for a while, it can't hurt to add it anyway. 😄 